### PR TITLE
fix: BuildGroupRenameMemberReq()

### DIFF
--- a/packets/oidb/GroupRenameMember.go
+++ b/packets/oidb/GroupRenameMember.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BuildGroupRenameMemberReq(groupUin uint32, uid, name string) (*OidbPacket, error) {
-	body := oidb.OidbSvcTrpcTcp0X8FC{
+	body := &oidb.OidbSvcTrpcTcp0X8FC{
 		GroupUin: groupUin,
 		Body: &oidb.OidbSvcTrpcTcp0X8FCBody{
 			TargetUid:  uid,


### PR DESCRIPTION
修复前会报错：proto.Marshal(oidb.OidbSvcTrpcTcp0X8FC): not a pointer