### PR TITLE
imp: err handle in QrcodeLogin() and Login()

### DIFF
--- a/utils/log.go
+++ b/utils/log.go
@@ -66,7 +66,9 @@ func (f *ColoredFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func GetLogger(prefix string) *logrus.Entry {
-	return logger.WithField("prefix", prefix)
+	log := logger.WithField("prefix", prefix)
+	log.Logger.ExitFunc = func(code int) {}
+	return log
 }
 
 func DisableLogOutput() {


### PR DESCRIPTION
默认的 `Logger.Fatal()` 会调用 `os.Exit()` 这是一个不太好的行为，仅返回错误即可