### PR TITLE
optimize(tea): apply fast speed from MiraiGo

### DIFF
--- a/packets/tlv/common.go
+++ b/packets/tlv/common.go
@@ -3,10 +3,9 @@ package tlv
 import (
 	"strconv"
 
-	"github.com/LagrangeDev/LagrangeGo/utils"
-
 	"github.com/LagrangeDev/LagrangeGo/info"
-	qqtea "github.com/LagrangeDev/LagrangeGo/utils/crypto"
+	"github.com/LagrangeDev/LagrangeGo/utils"
+	"github.com/LagrangeDev/LagrangeGo/utils/crypto"
 )
 
 // T18 默认参数 pingVersion, unknown = 0, ssoVersion = 5
@@ -60,7 +59,7 @@ func T106(appId, appClientVersion, uin int, guid string, passwordMd5, tgtgtKey, 
 		Pack(-1)
 
 	return utils.NewPacketBuilder(nil).
-		WriteBytes(qqtea.QQTeaEncrypt(body, key), "u32", true).
+		WriteBytes(crypto.NewTeaCipher(key).Encrypt(body), "u32", true).
 		Pack(0x106)
 }
 

--- a/utils/binary/builder.go
+++ b/utils/binary/builder.go
@@ -9,14 +9,16 @@ import (
 )
 
 type Builder struct {
-	buffer     []byte
-	encryptKey []byte
+	buffer []byte
+	key    crypto.TEA
+	usetea bool
 }
 
-func NewBuilder(encryptKey []byte) *Builder {
+func NewBuilder(key []byte) *Builder {
 	return &Builder{
-		buffer:     make([]byte, 0),
-		encryptKey: encryptKey,
+		buffer: make([]byte, 0),
+		key:    crypto.NewTeaCipher(key),
+		usetea: len(key) == 16,
 	}
 }
 
@@ -33,8 +35,8 @@ func (b *Builder) Buffer() []byte {
 }
 
 func (b *Builder) Data() []byte {
-	if b.encryptKey != nil {
-		return crypto.QQTeaEncrypt(b.buffer, b.encryptKey)
+	if b.usetea {
+		return b.key.Encrypt(b.buffer)
 	}
 	return b.buffer
 }

--- a/utils/crypto/tea.go
+++ b/utils/crypto/tea.go
@@ -1,210 +1,145 @@
 package crypto
 
+// from https://github.com/Mrs4s/MiraiGo/blob/master/binary/tea.go
+
 import (
-	"bytes"
 	"encoding/binary"
+	_ "unsafe" // required by go:linkname
 )
 
-// 使用utils里面的reader会循环引用
+type TEA [4]uint32
 
-type Reader struct {
-	buffer []byte
-	pos    int
-}
+// Encrypt tea 加密
+// http://bbs.chinaunix.net/thread-583468-1-1.html
+// 感谢xichen大佬对TEA的解释
+func (t TEA) Encrypt(src []byte) (dst []byte) {
+	lens := len(src)
+	fill := 10 - (lens+1)%8
+	dst = make([]byte, fill+lens+7)
+	dst[0] = byte(fill-3) | 0xF8 // 存储pad长度
+	copy(dst[fill:], src)
 
-func NewReader(buffer []byte) *Reader {
-	return &Reader{
-		buffer: buffer,
-		pos:    0,
-	}
-}
-
-func (r *Reader) ReadU32() (v uint32) {
-	v = binary.BigEndian.Uint32(r.buffer[r.pos : r.pos+4])
-	r.pos += 4
-	return
-}
-
-const (
-	DELTA = uint64(0x9E3779B9)
-	ROUND = 16
-	OP    = uint64(0xFFFFFFFF)
-)
-
-func xor(a, b []byte) []byte {
-	var a1, a2, b1, b2 uint32
-	readera := NewReader(a)
-	readerb := NewReader(b)
-
-	a1 = readera.ReadU32()
-	a2 = readera.ReadU32()
-	b1 = readerb.ReadU32()
-	b2 = readerb.ReadU32()
-	//_ = binary.Read(readera, binary.BigEndian, &a1)
-	//_ = binary.Read(readera, binary.BigEndian, &a2)
-	//_ = binary.Read(readerb, binary.BigEndian, &b1)
-	//_ = binary.Read(readerb, binary.BigEndian, &b2)
-
-	buf := make([]byte, 0)
-	buf = binary.BigEndian.AppendUint32(buf, (a1^b1)&uint32(OP))
-	buf = binary.BigEndian.AppendUint32(buf, (a2^b2)&uint32(OP))
-
-	return buf
-}
-
-func teaCode(v, k []byte) []byte {
-	var key0, key1, key2, key3, val0, val1 uint32
-	var k0, k1, k2, k3, v0, v1 uint64
-
-	//reader1 := bytes.NewReader(k)
-	//_ = binary.Read(reader1, binary.BigEndian, &key0)
-	//_ = binary.Read(reader1, binary.BigEndian, &key1)
-	//_ = binary.Read(reader1, binary.BigEndian, &key2)
-	//_ = binary.Read(reader1, binary.BigEndian, &key3)
-
-	reader1 := NewReader(k)
-	key0 = reader1.ReadU32()
-	key1 = reader1.ReadU32()
-	key2 = reader1.ReadU32()
-	key3 = reader1.ReadU32()
-
-	k0 = uint64(key0)
-	k1 = uint64(key1)
-	k2 = uint64(key2)
-	k3 = uint64(key3)
-
-	//reader2 := bytes.NewReader(v)
-	//_ = binary.Read(reader2, binary.BigEndian, &val0)
-	//_ = binary.Read(reader2, binary.BigEndian, &val1)
-
-	reader2 := NewReader(v)
-	val0 = reader2.ReadU32()
-	val1 = reader2.ReadU32()
-
-	v0 = uint64(val0)
-	v1 = uint64(val1)
-
-	sum := uint64(0)
-	for i := 0; i < ROUND; i++ {
-		sum += DELTA
-		v0 += ((OP & (v1 << 4)) + k0) ^ (v1 + sum) ^ ((OP & (v1 >> 5)) + k1)
-		v0 &= OP
-		v1 += ((OP & (v0 << 4)) + k2) ^ (v0 + sum) ^ ((OP & (v0 >> 5)) + k3)
-		v1 &= OP
+	var iv1, iv2, holder uint64
+	for i := 0; i < len(dst); i += 8 {
+		block := binary.BigEndian.Uint64(dst[i:])
+		holder = block ^ iv1
+		iv1 = t.encode(holder)
+		iv1 ^= iv2
+		iv2 = holder
+		binary.BigEndian.PutUint64(dst[i:], iv1)
 	}
 
-	buf := make([]byte, 0)
-	buf = binary.BigEndian.AppendUint32(buf, uint32(v0))
-	buf = binary.BigEndian.AppendUint32(buf, uint32(v1))
-
-	return buf
+	return dst
 }
 
-func teaDecipher(v, k []byte) []byte {
-	var key0, key1, key2, key3, val0, val1 uint32
-	var k0, k1, k2, k3, v0, v1 uint64
-
-	//reader1 := bytes.NewReader(k)
-	//_ = binary.Read(reader1, binary.BigEndian, &key0)
-	//_ = binary.Read(reader1, binary.BigEndian, &key1)
-	//_ = binary.Read(reader1, binary.BigEndian, &key2)
-	//_ = binary.Read(reader1, binary.BigEndian, &key3)
-
-	reader1 := NewReader(k)
-	key0 = reader1.ReadU32()
-	key1 = reader1.ReadU32()
-	key2 = reader1.ReadU32()
-	key3 = reader1.ReadU32()
-
-	k0 = uint64(key0)
-	k1 = uint64(key1)
-	k2 = uint64(key2)
-	k3 = uint64(key3)
-
-	//reader2 := bytes.NewReader(v)
-	//_ = binary.Read(reader2, binary.BigEndian, &val0)
-	//_ = binary.Read(reader2, binary.BigEndian, &val1)
-
-	reader2 := NewReader(v)
-	val0 = reader2.ReadU32()
-	val1 = reader2.ReadU32()
-
-	v0 = uint64(val0)
-	v1 = uint64(val1)
-
-	sum := DELTA << 4 & OP
-	for i := 0; i < ROUND; i++ {
-		v1 -= ((v0 << 4) + k2) ^ (v0 + sum) ^ ((v0 >> 5) + k3)
-		v1 &= OP
-		v0 -= ((v1 << 4) + k0) ^ (v1 + sum) ^ ((v1 >> 5) + k1)
-		v0 &= OP
-		sum -= DELTA
-		sum &= OP
-	}
-
-	buf := make([]byte, 0)
-	buf = binary.BigEndian.AppendUint32(buf, uint32(v0))
-	buf = binary.BigEndian.AppendUint32(buf, uint32(v1))
-
-	return buf
-}
-
-func preprocess(data []byte) []byte {
-	dataLen := len(data)
-	// 保证取余出来是正数
-	filln := ((8-(dataLen+2))%8+8)%8 + 2
-	fills := make([]byte, 0)
-	for i := 0; i < filln; i++ {
-		fills = append(fills, 220)
-	}
-	return append(append(append([]byte{byte((filln - 2) | 0xf8)}, fills...), data...), make([]byte, 7)...)
-}
-
-func encrypt(data, key []byte) []byte {
-	if len(key) < 16 {
-		panic("key length must be 16")
-	}
-
-	data = preprocess(data)
-	tr := make([]byte, 8)
-	to := make([]byte, 8)
-	result := make([]byte, 0)
-	for i := 0; i < len(data); i += 8 {
-		o := xor(data[i:i+8], tr)
-		tr = xor(teaCode(o, key), to)
-		to = o
-		result = append(result, tr...)
-	}
-	return result
-}
-
-func decrypt(text, key []byte) []byte {
-	if len(key) < 16 {
-		panic("key length must be 16")
-	}
-
-	dataLen := len(text)
-	plain := teaDecipher(text, key)
-	pos := (plain[0] & 0x07) + 2
-	ret := plain
-	precrypt := text[0:8]
-	for i := 8; i < dataLen; i += 8 {
-		x := xor(teaDecipher(xor(text[i:i+8], plain), key), precrypt)
-		plain = xor(x, precrypt)
-		precrypt = text[i : i+8]
-		ret = append(ret, x...)
-	}
-	if !bytes.Equal(ret[len(ret)-7:], make([]byte, 7)) {
+func (t TEA) Decrypt(data []byte) []byte {
+	if len(data) < 16 || len(data)%8 != 0 {
 		return nil
 	}
-
-	return ret[pos+1 : len(ret)-7]
+	dst := make([]byte, len(data))
+	var iv1, iv2, holder uint64
+	for i := 0; i < len(dst); i += 8 {
+		iv1 = binary.BigEndian.Uint64(data[i:])
+		iv2 ^= iv1
+		iv2 = t.decode(iv2)
+		binary.BigEndian.PutUint64(dst[i:], iv2^holder)
+		holder = iv1
+	}
+	return dst[dst[0]&7+3 : len(data)-7]
 }
 
-func QQTeaEncrypt(data, key []byte) []byte {
-	return encrypt(data, key)
+//go:nosplit
+func (t *TEA) encode(n uint64) uint64 {
+	v0, v1 := uint32(n>>32), uint32(n)
+	t0, t1, t2, t3 := t[0], t[1], t[2], t[3]
+
+	v0 += (v1 + 0x9e3779b9) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x9e3779b9) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x3c6ef372) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x3c6ef372) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xdaa66d2b) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xdaa66d2b) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x78dde6e4) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x78dde6e4) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x1715609d) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x1715609d) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xb54cda56) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xb54cda56) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x5384540f) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x5384540f) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xf1bbcdc8) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xf1bbcdc8) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x8ff34781) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x8ff34781) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x2e2ac13a) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x2e2ac13a) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xcc623af3) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xcc623af3) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x6a99b4ac) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x6a99b4ac) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x08d12e65) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x08d12e65) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xa708a81e) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xa708a81e) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0x454021d7) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0x454021d7) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 += (v1 + 0xe3779b90) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 += (v0 + 0xe3779b90) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+
+	return uint64(v0)<<32 | uint64(v1)
 }
 
-func QQTeaDecrypt(data, key []byte) []byte {
-	return decrypt(data, key)
+// 每次8字节
+//
+//go:nosplit
+func (t *TEA) decode(n uint64) uint64 {
+	v0, v1 := uint32(n>>32), uint32(n)
+	t0, t1, t2, t3 := t[0], t[1], t[2], t[3]
+
+	v1 -= (v0 + 0xe3779b90) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xe3779b90) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x454021d7) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x454021d7) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0xa708a81e) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xa708a81e) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x08d12e65) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x08d12e65) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x6a99b4ac) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x6a99b4ac) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0xcc623af3) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xcc623af3) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x2e2ac13a) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x2e2ac13a) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x8ff34781) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x8ff34781) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0xf1bbcdc8) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xf1bbcdc8) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x5384540f) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x5384540f) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0xb54cda56) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xb54cda56) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x1715609d) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x1715609d) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x78dde6e4) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x78dde6e4) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0xdaa66d2b) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0xdaa66d2b) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x3c6ef372) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x3c6ef372) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+	v1 -= (v0 + 0x9e3779b9) ^ (v0<<4 + t2) ^ (v0>>5 + t3)
+	v0 -= (v1 + 0x9e3779b9) ^ (v1<<4 + t0) ^ (v1>>5 + t1)
+
+	return uint64(v0)<<32 | uint64(v1)
+}
+
+//go:nosplit
+func NewTeaCipher(key []byte) (t TEA) {
+	if len(key) != 16 {
+		return TEA{}
+	}
+	t[3] = binary.BigEndian.Uint32(key[12:16])
+	t[2] = binary.BigEndian.Uint32(key[8:12])
+	t[1] = binary.BigEndian.Uint32(key[4:8])
+	t[0] = binary.BigEndian.Uint32(key[:4])
+	return t
 }

--- a/utils/crypto/tea_test.go
+++ b/utils/crypto/tea_test.go
@@ -1,63 +1,448 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
 	"testing"
 )
 
-func TestTea(t *testing.T) {
+func TestTeaOldNew(t *testing.T) {
 	s := "hello tea"
 	key := []byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}
-	encryp := QQTeaEncrypt([]byte(s), key)
-	raw := string(QQTeaDecrypt(encryp, key))
+	tea := NewTeaCipher(key)
+	encryp := oldencrypt([]byte(s), key)
+	raw := string(olddecrypt(encryp, key))
+	if s == raw {
+		t.Log("pass")
+	} else {
+		t.Error("fatal")
+	}
+	encnew := tea.Encrypt([]byte(s))
+	raw = string(olddecrypt(encnew, key))
+	if s == raw {
+		t.Log("pass")
+	} else {
+		t.Error("fatal")
+	}
+	encnew = oldencrypt([]byte(s), key)
+	raw = string(tea.Decrypt(encnew))
 	if s == raw {
 		t.Log("pass")
 	} else {
 		t.Error("fatal")
 	}
 }
-func BenchmarkTea(b *testing.B) {
-	b.Run("16-16", func(b *testing.B) {
-		data := getRandomBytes(16)
-		key := getRandomBytes(16)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			d := QQTeaEncrypt(data, key)
-			_ = QQTeaDecrypt(d, key)
-		}
-	})
-	b.Run("512-16", func(b *testing.B) {
-		data := getRandomBytes(512)
-		key := getRandomBytes(16)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			d := QQTeaEncrypt(data, key)
-			_ = QQTeaDecrypt(d, key)
-		}
-	})
-	b.Run("1024-16", func(b *testing.B) {
-		data := getRandomBytes(1024)
-		key := getRandomBytes(16)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			d := QQTeaEncrypt(data, key)
-			_ = QQTeaDecrypt(d, key)
-		}
-	})
-	b.Run("2048-16", func(b *testing.B) {
-		data := getRandomBytes(2048)
-		key := getRandomBytes(16)
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			d := QQTeaEncrypt(data, key)
-			_ = QQTeaDecrypt(d, key)
-		}
-	})
 
+// below from https://github.com/Mrs4s/MiraiGo/blob/master/binary/tea_test.go
+
+var testTEA = NewTeaCipher([]byte("0123456789ABCDEF"))
+
+const (
+	KEY = iota
+	DAT
+	ENC
+)
+
+var sampleData = func() [][3]string {
+	out := [][3]string{
+		{"0123456789ABCDEF", "MiraiGO Here", "b7b2e52af7f5b1fbf37fc3d5546ac7569aecd01bbacf09bf"},
+		{"0123456789ABCDEF", "LXY Testing~", "9d0ab85aa14f5434ee83cd2a6b28bf306263cdf88e01264c"},
+
+		{"0123456789ABCDEF", "s", "528e8b5c48300b548e94262736ebb8b7"},
+		{"0123456789ABCDEF", "long long long long long long long", "95715fab6efbd0fd4b76dbc80bd633ebe805849dbc242053b06557f87e748effd9f613f782749fb9fdfa3f45c0c26161"},
+
+		{"LXY1226    Mrs4s", "LXY Testing~", "ab20caa63f3a6503a84f3cb28f9e26b6c18c051e995d1721"},
+	}
+	for i := range out {
+		c, _ := hex.DecodeString(out[i][ENC])
+		out[i][ENC] = string(c)
+	}
+	return out
+}()
+
+func TestTEA(t *testing.T) {
+	// Self Testing
+	for _, sample := range sampleData {
+		tea := NewTeaCipher([]byte(sample[KEY]))
+		dat := string(tea.Decrypt([]byte(sample[ENC])))
+		if dat != sample[DAT] {
+			t.Fatalf("error decrypt %v %x", sample, dat)
+		}
+		enc := string(tea.Encrypt([]byte(sample[DAT])))
+		dat = string(tea.Decrypt([]byte(enc)))
+		if dat != sample[DAT] {
+			t.Fatal("error self test", sample)
+		}
+	}
+
+	key := make([]byte, 16)
+	_, err := rand.Read(key)
+	if err != nil {
+		panic(err)
+	}
+	// Random data testing
+	for i := 1; i < 0xFF; i++ {
+		_, err := rand.Read(key)
+		if err != nil {
+			panic(err)
+		}
+		tea := NewTeaCipher(key)
+
+		dat := make([]byte, i)
+		_, err = rand.Read(dat)
+		if err != nil {
+			panic(err)
+		}
+		enc := tea.Encrypt(dat)
+		dec := tea.Decrypt(enc)
+		if !bytes.Equal(dat, dec) {
+			t.Fatalf("error in %d, %x %x %x", i, key, dat, enc)
+		}
+	}
 }
 
-func getRandomBytes(n int) (data []byte) {
-	data = make([]byte, n)
-	_, _ = rand.Read(data)
+func benchEncrypt(b *testing.B, data []byte) {
+	_, err := rand.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testTEA.Encrypt(data)
+	}
+}
+
+func benchDecrypt(b *testing.B, data []byte) {
+	_, err := rand.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	data = testTEA.Encrypt(data)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		testTEA.Decrypt(data)
+	}
+}
+
+func BenchmarkTEAen(b *testing.B) {
+	b.Run("16", func(b *testing.B) {
+		data := make([]byte, 16)
+		benchEncrypt(b, data)
+	})
+	b.Run("256", func(b *testing.B) {
+		data := make([]byte, 256)
+		benchEncrypt(b, data)
+	})
+	b.Run("4K", func(b *testing.B) {
+		data := make([]byte, 1024*4)
+		benchEncrypt(b, data)
+	})
+	b.Run("32K", func(b *testing.B) {
+		data := make([]byte, 1024*32)
+		benchEncrypt(b, data)
+	})
+}
+
+func BenchmarkTEAde(b *testing.B) {
+	b.Run("16", func(b *testing.B) {
+		data := make([]byte, 16)
+		benchDecrypt(b, data)
+	})
+	b.Run("256", func(b *testing.B) {
+		data := make([]byte, 256)
+		benchDecrypt(b, data)
+	})
+	b.Run("4K", func(b *testing.B) {
+		data := make([]byte, 4096)
+		benchDecrypt(b, data)
+	})
+	b.Run("32K", func(b *testing.B) {
+		data := make([]byte, 1024*32)
+		benchDecrypt(b, data)
+	})
+}
+
+func BenchmarkTEA_encode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testTEA.encode(114514)
+	}
+}
+
+func BenchmarkTEA_decode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		testTEA.decode(114514)
+	}
+}
+
+// above from https://github.com/Mrs4s/MiraiGo/blob/master/binary/tea_test.go
+
+func benchOldEncrypt(b *testing.B, data []byte) {
+	_, err := rand.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		olddecrypt(data, []byte("0123456789ABCDEF"))
+	}
+}
+
+func benchOldDecrypt(b *testing.B, data []byte) {
+	_, err := rand.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	data = testTEA.Encrypt(data)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		olddecrypt(data, []byte("0123456789ABCDEF"))
+	}
+}
+
+func BenchmarkOldTEAen(b *testing.B) {
+	b.Run("16", func(b *testing.B) {
+		data := make([]byte, 16)
+		benchOldEncrypt(b, data)
+	})
+	b.Run("256", func(b *testing.B) {
+		data := make([]byte, 256)
+		benchOldEncrypt(b, data)
+	})
+	b.Run("4K", func(b *testing.B) {
+		data := make([]byte, 1024*4)
+		benchOldEncrypt(b, data)
+	})
+	b.Run("32K", func(b *testing.B) {
+		data := make([]byte, 1024*32)
+		benchOldEncrypt(b, data)
+	})
+}
+
+func BenchmarkOldTEAde(b *testing.B) {
+	b.Run("16", func(b *testing.B) {
+		data := make([]byte, 16)
+		benchOldDecrypt(b, data)
+	})
+	b.Run("256", func(b *testing.B) {
+		data := make([]byte, 256)
+		benchOldDecrypt(b, data)
+	})
+	b.Run("4K", func(b *testing.B) {
+		data := make([]byte, 4096)
+		benchOldDecrypt(b, data)
+	})
+	b.Run("32K", func(b *testing.B) {
+		data := make([]byte, 1024*32)
+		benchOldDecrypt(b, data)
+	})
+}
+
+// 使用utils里面的reader会循环引用
+
+type testreader struct {
+	buffer []byte
+	pos    int
+}
+
+func newtestreader(buffer []byte) *testreader {
+	return &testreader{
+		buffer: buffer,
+		pos:    0,
+	}
+}
+
+func (r *testreader) ReadU32() (v uint32) {
+	v = binary.BigEndian.Uint32(r.buffer[r.pos : r.pos+4])
+	r.pos += 4
 	return
+}
+
+const (
+	DELTA = uint64(0x9E3779B9)
+	ROUND = 16
+	OP    = uint64(0xFFFFFFFF)
+)
+
+func xor(a, b []byte) []byte {
+	var a1, a2, b1, b2 uint32
+	readera := newtestreader(a)
+	readerb := newtestreader(b)
+
+	a1 = readera.ReadU32()
+	a2 = readera.ReadU32()
+	b1 = readerb.ReadU32()
+	b2 = readerb.ReadU32()
+	//_ = binary.Read(readera, binary.BigEndian, &a1)
+	//_ = binary.Read(readera, binary.BigEndian, &a2)
+	//_ = binary.Read(readerb, binary.BigEndian, &b1)
+	//_ = binary.Read(readerb, binary.BigEndian, &b2)
+
+	buf := make([]byte, 0)
+	buf = binary.BigEndian.AppendUint32(buf, (a1^b1)&uint32(OP))
+	buf = binary.BigEndian.AppendUint32(buf, (a2^b2)&uint32(OP))
+
+	return buf
+}
+
+func teaCode(v, k []byte) []byte {
+	var key0, key1, key2, key3, val0, val1 uint32
+	var k0, k1, k2, k3, v0, v1 uint64
+
+	//reader1 := bytes.NewReader(k)
+	//_ = binary.Read(reader1, binary.BigEndian, &key0)
+	//_ = binary.Read(reader1, binary.BigEndian, &key1)
+	//_ = binary.Read(reader1, binary.BigEndian, &key2)
+	//_ = binary.Read(reader1, binary.BigEndian, &key3)
+
+	reader1 := newtestreader(k)
+	key0 = reader1.ReadU32()
+	key1 = reader1.ReadU32()
+	key2 = reader1.ReadU32()
+	key3 = reader1.ReadU32()
+
+	k0 = uint64(key0)
+	k1 = uint64(key1)
+	k2 = uint64(key2)
+	k3 = uint64(key3)
+
+	//reader2 := bytes.NewReader(v)
+	//_ = binary.Read(reader2, binary.BigEndian, &val0)
+	//_ = binary.Read(reader2, binary.BigEndian, &val1)
+
+	reader2 := newtestreader(v)
+	val0 = reader2.ReadU32()
+	val1 = reader2.ReadU32()
+
+	v0 = uint64(val0)
+	v1 = uint64(val1)
+
+	sum := uint64(0)
+	for i := 0; i < ROUND; i++ {
+		sum += DELTA
+		v0 += ((OP & (v1 << 4)) + k0) ^ (v1 + sum) ^ ((OP & (v1 >> 5)) + k1)
+		v0 &= OP
+		v1 += ((OP & (v0 << 4)) + k2) ^ (v0 + sum) ^ ((OP & (v0 >> 5)) + k3)
+		v1 &= OP
+	}
+
+	buf := make([]byte, 0)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(v0))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(v1))
+
+	return buf
+}
+
+func teaDecipher(v, k []byte) []byte {
+	var key0, key1, key2, key3, val0, val1 uint32
+	var k0, k1, k2, k3, v0, v1 uint64
+
+	//reader1 := bytes.NewReader(k)
+	//_ = binary.Read(reader1, binary.BigEndian, &key0)
+	//_ = binary.Read(reader1, binary.BigEndian, &key1)
+	//_ = binary.Read(reader1, binary.BigEndian, &key2)
+	//_ = binary.Read(reader1, binary.BigEndian, &key3)
+
+	reader1 := newtestreader(k)
+	key0 = reader1.ReadU32()
+	key1 = reader1.ReadU32()
+	key2 = reader1.ReadU32()
+	key3 = reader1.ReadU32()
+
+	k0 = uint64(key0)
+	k1 = uint64(key1)
+	k2 = uint64(key2)
+	k3 = uint64(key3)
+
+	//reader2 := bytes.NewReader(v)
+	//_ = binary.Read(reader2, binary.BigEndian, &val0)
+	//_ = binary.Read(reader2, binary.BigEndian, &val1)
+
+	reader2 := newtestreader(v)
+	val0 = reader2.ReadU32()
+	val1 = reader2.ReadU32()
+
+	v0 = uint64(val0)
+	v1 = uint64(val1)
+
+	sum := DELTA << 4 & OP
+	for i := 0; i < ROUND; i++ {
+		v1 -= ((v0 << 4) + k2) ^ (v0 + sum) ^ ((v0 >> 5) + k3)
+		v1 &= OP
+		v0 -= ((v1 << 4) + k0) ^ (v1 + sum) ^ ((v1 >> 5) + k1)
+		v0 &= OP
+		sum -= DELTA
+		sum &= OP
+	}
+
+	buf := make([]byte, 0)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(v0))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(v1))
+
+	return buf
+}
+
+func preprocess(data []byte) []byte {
+	dataLen := len(data)
+	// 保证取余出来是正数
+	filln := ((8-(dataLen+2))%8+8)%8 + 2
+	fills := make([]byte, 0)
+	for i := 0; i < filln; i++ {
+		fills = append(fills, 220)
+	}
+	return append(append(append([]byte{byte((filln - 2) | 0xf8)}, fills...), data...), make([]byte, 7)...)
+}
+
+func encrypt(data, key []byte) []byte {
+	if len(key) < 16 {
+		panic("key length must be 16")
+	}
+
+	data = preprocess(data)
+	tr := make([]byte, 8)
+	to := make([]byte, 8)
+	result := make([]byte, 0)
+	for i := 0; i < len(data); i += 8 {
+		o := xor(data[i:i+8], tr)
+		tr = xor(teaCode(o, key), to)
+		to = o
+		result = append(result, tr...)
+	}
+	return result
+}
+
+func decrypt(text, key []byte) []byte {
+	if len(key) < 16 {
+		panic("key length must be 16")
+	}
+
+	dataLen := len(text)
+	plain := teaDecipher(text, key)
+	pos := (plain[0] & 0x07) + 2
+	ret := plain
+	precrypt := text[0:8]
+	for i := 8; i < dataLen; i += 8 {
+		x := xor(teaDecipher(xor(text[i:i+8], plain), key), precrypt)
+		plain = xor(x, precrypt)
+		precrypt = text[i : i+8]
+		ret = append(ret, x...)
+	}
+	if !bytes.Equal(ret[len(ret)-7:], make([]byte, 7)) {
+		return nil
+	}
+
+	return ret[pos+1 : len(ret)-7]
+}
+
+func oldencrypt(data, key []byte) []byte {
+	return encrypt(data, key)
+}
+
+func olddecrypt(data, key []byte) []byte {
+	return decrypt(data, key)
 }

--- a/utils/packet.go
+++ b/utils/packet.go
@@ -9,14 +9,16 @@ import (
 )
 
 type PacketBuilder struct {
-	buffer     []byte
-	encryptKey []byte
+	buffer []byte
+	key    crypto.TEA
+	usetea bool
 }
 
-func NewPacketBuilder(encryptKey []byte) *PacketBuilder {
+func NewPacketBuilder(key []byte) *PacketBuilder {
 	return &PacketBuilder{
-		buffer:     make([]byte, 0),
-		encryptKey: encryptKey,
+		buffer: make([]byte, 0),
+		key:    crypto.NewTeaCipher(key),
+		usetea: len(key) == 16,
 	}
 }
 
@@ -75,8 +77,8 @@ func (b *PacketBuilder) Buffer() []byte {
 }
 
 func (b *PacketBuilder) Data() []byte {
-	if b.encryptKey != nil {
-		return crypto.QQTeaEncrypt(b.buffer, b.encryptKey)
+	if b.usetea {
+		return b.key.Encrypt(b.buffer)
 	}
 	return b.buffer
 }


### PR DESCRIPTION
应用经过优化的TEA。
```
goos: darwin
goarch: arm64
pkg: github.com/LagrangeDev/LagrangeGo/utils/crypto
            │ utils/crypto/old.txt │        utils/crypto/new.txt         │
            │        sec/op        │   sec/op     vs base                │
TEAen/16-8             195.5n ± 0%   225.7n ± 3%  +15.42% (p=0.000 n=10)
TEAen/256-8            3.734µ ± 0%   1.924µ ± 1%  -48.47% (p=0.000 n=10)
TEAen/4K-8             58.59µ ± 0%   29.05µ ± 0%  -50.42% (p=0.000 n=10)
TEAen/32K-8            468.9µ ± 1%   228.3µ ± 0%  -51.30% (p=0.000 n=10)
TEAde/16-8             452.9n ± 0%   254.7n ± 0%  -43.76% (p=0.000 n=10)
TEAde/256-8            4.046µ ± 0%   2.218µ ± 1%  -45.19% (p=0.000 n=10)
TEAde/4K-8             59.70µ ± 0%   33.56µ ± 0%  -43.77% (p=0.000 n=10)
TEAde/32K-8            474.1µ ± 0%   268.0µ ± 1%  -43.48% (p=0.000 n=10)
geomean                13.40µ        7.864µ       -41.32%

            │ utils/crypto/old.txt │          utils/crypto/new.txt          │
            │         B/s          │      B/s       vs base                 │
TEAen/16-8            78.05Mi ± 0%    67.61Mi ± 3%   -13.37% (p=0.000 n=10)
TEAen/256-8           65.39Mi ± 0%   126.89Mi ± 1%   +94.04% (p=0.000 n=10)
TEAen/4K-8            66.67Mi ± 0%   134.48Mi ± 0%  +101.72% (p=0.000 n=10)
TEAen/32K-8           66.65Mi ± 1%   136.86Mi ± 0%  +105.33% (p=0.000 n=10)
TEAde/16-8            67.39Mi ± 0%   119.82Mi ± 0%   +77.81% (p=0.000 n=10)
TEAde/256-8           64.11Mi ± 0%   116.98Mi ± 1%   +82.46% (p=0.000 n=10)
TEAde/4K-8            65.69Mi ± 0%   116.84Mi ± 0%   +77.87% (p=0.000 n=10)
TEAde/32K-8           65.95Mi ± 0%   116.67Mi ± 1%   +76.92% (p=0.000 n=10)
geomean               67.37Mi         114.8Mi        +70.40%

            │ utils/crypto/old.txt │         utils/crypto/new.txt         │
            │         B/op         │     B/op      vs base                │
TEAen/16-8              56.00 ± 0%     32.00 ± 0%  -42.86% (p=0.000 n=10)
TEAen/256-8            1496.0 ± 0%     288.0 ± 0%  -80.75% (p=0.000 n=10)
TEAen/4K-8           28.211Ki ± 0%   4.750Ki ± 0%  -83.16% (p=0.000 n=10)
TEAen/32K-8          278.71Ki ± 0%   40.00Ki ± 0%  -85.65% (p=0.000 n=10)
TEAde/16-8             152.00 ± 0%     32.00 ± 0%  -78.95% (p=0.000 n=10)
TEAde/256-8            2072.0 ± 0%     288.0 ± 0%  -86.10% (p=0.000 n=10)
TEAde/4K-8           33.523Ki ± 0%   4.750Ki ± 0%  -85.83% (p=0.000 n=10)
TEAde/32K-8          278.78Ki ± 0%   40.00Ki ± 0%  -85.65% (p=0.000 n=10)
geomean               6.037Ki        1.137Ki       -81.17%

            │ utils/crypto/old.txt │        utils/crypto/new.txt        │
            │      allocs/op       │ allocs/op   vs base                │
TEAen/16-8              6.000 ± 0%   1.000 ± 0%  -83.33% (p=0.000 n=10)
TEAen/256-8           130.000 ± 0%   1.000 ± 0%  -99.23% (p=0.000 n=10)
TEAen/4K-8           2056.000 ± 0%   1.000 ± 0%  -99.95% (p=0.000 n=10)
TEAen/32K-8         16400.000 ± 0%   1.000 ± 0%  -99.99% (p=0.000 n=10)
TEAde/16-8             15.000 ± 0%   1.000 ± 0%  -93.33% (p=0.000 n=10)
TEAde/256-8           139.000 ± 0%   1.000 ± 0%  -99.28% (p=0.000 n=10)
TEAde/4K-8           2065.000 ± 0%   1.000 ± 0%  -99.95% (p=0.000 n=10)
TEAde/32K-8         16408.000 ± 0%   1.000 ± 0%  -99.99% (p=0.000 n=10)
geomean                 455.6        1.000       -99.78%
```