### PR TITLE
optimize(builder): split WriteLenBytes and WriteBytes

### DIFF
--- a/client/base.go
+++ b/client/base.go
@@ -191,9 +191,9 @@ func (c *QQClient) OnMessage(msgLen int) {
 				fetcher.AddResult(packet.Seq, packet)
 			}
 		} else { // server pushed
-			if _, ok := listeners[packet.Cmd]; ok {
+			if fn, ok := listeners[packet.Cmd]; ok {
 				networkLogger.Debugf("Server Push(%d) <- %s, extra: %s", packet.RetCode, packet.Cmd, packet.Extra)
-				msg, err := listeners[packet.Cmd](c, packet)
+				msg, err := fn(c, packet)
 				if err != nil {
 					return
 				}

--- a/client/client.go
+++ b/client/client.go
@@ -256,7 +256,7 @@ func (c *QQClient) QrcodeLogin(refreshInterval int) error {
 	body := binary.NewBuilder(nil).
 		WriteU16(0x09).
 		WriteTlv(
-			binary.NewBuilder(nil).WriteBytes(c.t106, false).Pack(0x106),
+			binary.NewBuilder(nil).WriteBytes(c.t106).Pack(0x106),
 			tlv.T144(c.sig.Tgtgt, app, device),
 			tlv.T116(app.SubSigmap),
 			tlv.T142(app.PackageName, 0),
@@ -268,7 +268,7 @@ func (c *QQClient) QrcodeLogin(refreshInterval int) error {
 			tlv.T100(5, app.AppID, app.SubAppID, 8001, app.MainSigmap, 0),
 			tlv.T107(1, 0x0d, 0, 1),
 			tlv.T318(nil),
-			binary.NewBuilder(nil).WriteBytes(c.t16a, false).Pack(0x16a),
+			binary.NewBuilder(nil).WriteBytes(c.t16a).Pack(0x16a),
 			tlv.T166(5),
 			tlv.T521(0x13, "basicim"),
 		).ToBytes()

--- a/client/highway.go
+++ b/client/highway.go
@@ -186,10 +186,10 @@ func sendHighwayPacket(packet *highway.ReqDataHighwayHead, buffer io.Reader, buf
 	}
 
 	writer := binary.NewBuilder(nil).
-		WriteBytes([]byte{0x28}, false).
+		WriteBytes([]byte{0x28}).
 		WriteU32(uint32(len(marshal))).
 		WriteU32(bufferSize).
-		WriteBytes(marshal, false)
+		WriteBytes(marshal)
 	_, _ = io.Copy(writer, buffer)
 	_, _ = writer.Write([]byte{0x29})
 

--- a/info/serialize.go
+++ b/info/serialize.go
@@ -29,8 +29,8 @@ func Encode(sig *SigInfo) ([]byte, error) {
 	dataHash := crypto.MD5Digest(buffer.Bytes())
 
 	return binary.NewBuilder(nil).
-		WriteBytes(dataHash, true).
-		WriteBytes(buffer.Bytes(), true).
+		WriteLenBytes(dataHash).
+		WriteLenBytes(buffer.Bytes()).
 		ToBytes(), nil
 }
 

--- a/packets/tlv/common.go
+++ b/packets/tlv/common.go
@@ -49,13 +49,13 @@ func T106(appId, appClientVersion, uin int, guid string, passwordMd5, tgtgtKey, 
 			uint32(appClientVersion),
 			uint64(uin)).
 		WriteU32(uint32(utils.TimeStamp())).
-		WriteBytes(ip, false).
+		WriteBytes(ip).
 		WriteBool(savePassword).
-		WriteBytes(passwordMd5, false).
-		WriteBytes(tgtgtKey, false).
+		WriteBytes(passwordMd5).
+		WriteBytes(tgtgtKey).
 		WriteU32(0).
 		WriteBool(true).
-		WriteBytes(utils.MustParseHexStr(guid), false).
+		WriteBytes(utils.MustParseHexStr(guid)).
 		WriteU32(0).
 		WriteU32(1).
 		WritePacketString(strconv.Itoa(uin), "u16", false).
@@ -87,7 +87,7 @@ func T116(subSigmap int) []byte {
 
 func T124() []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(make([]byte, 12), false).
+		WriteBytes(make([]byte, 12)).
 		Pack(0x124)
 }
 
@@ -134,7 +134,7 @@ func T144(tgtgtKey []byte, appInfo *info.AppInfo, device *info.DeviceInfo) []byt
 
 func T145(guid []byte) []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(guid, false).
+		WriteBytes(guid).
 		Pack(0x145)
 }
 
@@ -154,13 +154,13 @@ func T166(imageType int) []byte {
 
 func T16a(noPicSig []byte) []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(noPicSig, false).
+		WriteBytes(noPicSig).
 		Pack(0x16a)
 }
 
 func T16e(deviceName string) []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(utils.S2B(deviceName), false).
+		WriteBytes(utils.S2B(deviceName)).
 		Pack(0x16e)
 }
 
@@ -182,7 +182,7 @@ func T191(canWebVerify int) []byte {
 // T318 默认参数 tgtQr = []byte{0}
 func T318(tgtQr []byte) []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(tgtQr, false).
+		WriteBytes(tgtQr).
 		Pack(0x318)
 }
 

--- a/packets/tlv/qrcode.go
+++ b/packets/tlv/qrcode.go
@@ -7,7 +7,7 @@ import (
 
 func T11(unusualSign []byte) []byte {
 	return binary.NewBuilder(nil).
-		WriteBytes(unusualSign, false).
+		WriteBytes(unusualSign).
 		Pack(0x11)
 }
 
@@ -16,7 +16,7 @@ func T16(appid, subAppid int, guid []byte, ptVersion, packageName string) []byte
 		WriteU32(0).
 		WriteU32(uint32(appid)).
 		WriteU32(uint32(subAppid)).
-		WriteBytes(guid, false).
+		WriteBytes(guid).
 		WritePacketString(packageName, "u16", false).
 		WritePacketString(ptVersion, "u16", false).
 		WritePacketString(packageName, "u16", false).
@@ -39,7 +39,7 @@ func T1d(miscBitmap int) []byte {
 }
 
 func T33(guid []byte) []byte {
-	return binary.NewBuilder(nil).WriteBytes(guid, false).Pack(0x33)
+	return binary.NewBuilder(nil).WriteBytes(guid).Pack(0x33)
 }
 
 func T35(PtOSVersion int) []byte {
@@ -60,6 +60,6 @@ func Td1(AppOS, DeviceName string) []byte {
 			4: proto.DynamicMessage{
 				6: 1,
 			},
-		}.Encode(), false).
+		}.Encode()).
 		Pack(0xd1)
 }

--- a/packets/wtlogin/exchange.go
+++ b/packets/wtlogin/exchange.go
@@ -25,9 +25,9 @@ func BuildKexExchangeRequest(uin uint32, guid string) ([]byte, error) {
 
 	p2Hash := crypto.SHA256Digest(
 		binary.NewBuilder(nil).
-			WriteBytes(ecdh.P256().PublicKey(), false).
+			WriteBytes(ecdh.P256().PublicKey()).
 			WriteU32(1).
-			WriteBytes(encl, false).
+			WriteBytes(encl).
 			WriteU32(0).
 			WriteU32(uint32(utils.TimeStamp())).
 			ToBytes(),

--- a/packets/wtlogin/oicq.go
+++ b/packets/wtlogin/oicq.go
@@ -28,17 +28,17 @@ func BuildCode2dPacket(uin uint32, cmdID int, appInfo *info.AppInfo, body []byte
 			WriteU16(uint16(len(body))+53).
 			WriteU32(uint32(appInfo.AppID)).
 			WriteU32(0x72).
-			WriteBytes(make([]byte, 3), false).
+			WriteBytes(make([]byte, 3)).
 			WriteU32(uint32(utils.TimeStamp())).
 			WriteU8(2).
 			WriteU16(uint16(len(body)+49)).
 			WriteU16(uint16(cmdID)).
-			WriteBytes(make([]byte, 21), false).
+			WriteBytes(make([]byte, 21)).
 			WriteU8(3).
 			WriteU32(50).
-			WriteBytes(make([]byte, 14), false).
+			WriteBytes(make([]byte, 14)).
 			WriteU32(uint32(appInfo.AppID)).
-			WriteBytes(body, false).
+			WriteBytes(body).
 			ToBytes(),
 	)
 }
@@ -69,18 +69,18 @@ func BuildLoginPacket(uin uint32, cmd string, appinfo *info.AppInfo, body []byte
 		WriteU32(0).
 		WriteU8(1).
 		WriteU8(1).
-		WriteBytes(make([]byte, 16), false).
+		WriteBytes(make([]byte, 16)).
 		WriteU16(0x102).
 		WriteU16(uint16(len(pk))).
-		WriteBytes(pk, false).
-		WriteBytes(encBody, false).
+		WriteBytes(pk).
+		WriteBytes(encBody).
 		WriteU8(3).
 		ToBytes()
 
 	frame := binary.NewBuilder(nil).
 		WriteU8(2).
-		WriteU16(uint16(len(frameBody))+3). // + 2 + 1
-		WriteBytes(frameBody, false).
+		WriteU16(uint16(len(frameBody)) + 3). // + 2 + 1
+		WriteBytes(frameBody).
 		ToBytes()
 
 	return frame
@@ -107,8 +107,8 @@ func BuildUniPacket(uin int, seq uint32, cmd string, sign map[string]string,
 	ssoHeader := binary.NewBuilder(nil).
 		WriteU32(uint32(seq)).
 		WriteU32(uint32(appInfo.SubAppID)).
-		WriteU32(2052).                                               // locate id
-		WriteBytes(append([]byte{0x02}, make([]byte, 11)...), false). //020000000000000000000000
+		WriteU32(2052).                                        // locate id
+		WriteBytes(append([]byte{0x02}, make([]byte, 11)...)). //020000000000000000000000
 		WritePacketBytes(sigInfo.Tgt, "u32", true).
 		WritePacketString(cmd, "u32", true).
 		WritePacketBytes(nil, "u32", true).
@@ -138,7 +138,7 @@ func BuildUniPacket(uin int, seq uint32, cmd string, sign map[string]string,
 		WritePacketBytes(sigInfo.D2, "u32", true).
 		WriteU8(0).
 		WritePacketString(strconv.Itoa(uin), "u32", true).
-		WriteBytes(encrypted, false).
+		WriteBytes(encrypted).
 		ToBytes()
 
 	return binary.NewBuilder(nil).WritePacketBytes(service, "u32", true).ToBytes()

--- a/utils/binary/builder.go
+++ b/utils/binary/builder.go
@@ -122,16 +122,19 @@ func (b *Builder) ReadFrom(r io.Reader) (n int64, err error) {
 	return io.Copy(b.buffer, r)
 }
 
-func (b *Builder) WriteBytes(v []byte, withLength bool) *Builder {
-	if withLength {
-		b.WriteU16(uint16(len(v)))
-	}
+func (b *Builder) WriteLenBytes(v []byte) *Builder {
+	b.WriteU16(uint16(len(v)))
 	b.append(v)
 	return b
 }
 
-func (b *Builder) WriteString(v string) *Builder {
-	return b.WriteBytes(utils.S2B(v), true)
+func (b *Builder) WriteBytes(v []byte) *Builder {
+	b.append(v)
+	return b
+}
+
+func (b *Builder) WriteLenString(v string) *Builder {
+	return b.WriteLenBytes(utils.S2B(v))
 }
 
 func (b *Builder) WriteStruct(data ...any) *Builder {
@@ -195,7 +198,7 @@ func (b *Builder) WriteDouble(v float64) *Builder {
 func (b *Builder) WriteTlv(tlvs ...[]byte) *Builder {
 	b.WriteU16(uint16(len(tlvs)))
 	for _, tlv := range tlvs {
-		b.WriteBytes(tlv, false)
+		b.WriteBytes(tlv)
 	}
 	return b
 }

--- a/utils/binary/builder_test.go
+++ b/utils/binary/builder_test.go
@@ -7,13 +7,13 @@ import (
 
 func TestBuilder(t *testing.T) {
 	r := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	data := NewBuilder(nil).WriteBytes(r, true).ToBytes()
+	data := NewBuilder(nil).WriteLenBytes(r).ToBytes()
 	fmt.Printf("%x\n", data)
 }
 
 func build() []byte {
 	r := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	return NewBuilder(nil).WriteBytes(r, true).WriteBytes(r, true).ToBytes()
+	return NewBuilder(nil).WriteLenBytes(r).WriteLenBytes(r).ToBytes()
 }
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
注意到WriteBytes第二个参数大多为false，因此直接将WriteBytes分开。