### PR TITLE
optimize(cache): drop useless expire time

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -121,13 +121,17 @@ func (c *QQClient) GetCachedRkeyInfos() map[entity.RKeyType]*entity.RKeyInfo {
 			if err := c.RefreshAllRkeyInfoCache(); err != nil {
 				return nil
 			}
+			refresh = false
 		}
 		inf := c.cache.GetAllRkeyInfo()
 		for _, v := range inf {
 			if v.ExpireTime <= uint64(time.Now().Unix()) {
 				refresh = true
-				continue
+				break
 			}
+		}
+		if refresh {
+			continue
 		}
 		return inf
 	}

--- a/client/internal/cache/cache.go
+++ b/client/internal/cache/cache.go
@@ -1,6 +1,8 @@
 package cache
 
-import "github.com/LagrangeDev/LagrangeGo/client/entity"
+import (
+	"github.com/LagrangeDev/LagrangeGo/client/entity"
+)
 
 // GetUid 根据uin获取uid
 func (c *Cache) GetUid(uin uint32, groupUin ...uint32) string {
@@ -88,7 +90,7 @@ func (c *Cache) GetGroupMember(uin, groupUin uint32) *entity.GroupMember {
 func (c *Cache) GetGroupMembers(groupUin uint32) map[uint32]*entity.GroupMember {
 	members := make(map[uint32]*entity.GroupMember, 64)
 	if group, ok := getCacheOf[Cache](c, groupUin); ok {
-		rangeCacheOf[entity.GroupMember](group, func(k uint32, member *entity.GroupMember) bool {
+		rangeCacheOf(group, func(k uint32, member *entity.GroupMember) bool {
 			members[member.Uin] = member
 			return true
 		})
@@ -105,7 +107,7 @@ func (c *Cache) GetRKeyInfo(rkeyType entity.RKeyType) *entity.RKeyInfo {
 // GetAllRkeyInfo 获取所有RKey信息
 func (c *Cache) GetAllRkeyInfo() entity.RKeyMap {
 	infos := make(map[entity.RKeyType]*entity.RKeyInfo, 2)
-	rangeCacheOf[entity.RKeyInfo](c, func(k entity.RKeyType, v *entity.RKeyInfo) bool {
+	rangeCacheOf(c, func(k entity.RKeyType, v *entity.RKeyInfo) bool {
 		infos[k] = v
 		return true
 	})
@@ -138,8 +140,4 @@ func (c *Cache) GroupInfoCacheIsEmpty() bool {
 // RkeyInfoCacheIsEmpty RKey缓存是否为空
 func (c *Cache) RkeyInfoCacheIsEmpty() bool {
 	return !hasRefreshed[entity.RKeyInfo](c)
-}
-
-func (c *Cache) RkeyInfoCacheIsExpired() bool {
-	return hasExpired[entity.RKeyInfo](c)
 }

--- a/client/internal/cache/operation.go
+++ b/client/internal/cache/operation.go
@@ -2,10 +2,14 @@ package cache
 
 import (
 	"github.com/LagrangeDev/LagrangeGo/client/entity"
-	"math"
 )
 
-func (c *Cache) RefreshAll(friendCache map[uint32]*entity.Friend, groupCache map[uint32]*entity.Group, groupMemberCache map[uint32]map[uint32]*entity.GroupMember, rkeyCache entity.RKeyMap) {
+func (c *Cache) RefreshAll(
+	friendCache map[uint32]*entity.Friend,
+	groupCache map[uint32]*entity.Group,
+	groupMemberCache map[uint32]map[uint32]*entity.GroupMember,
+	rkeyCache entity.RKeyMap,
+) {
 	c.RefreshAllFriend(friendCache)
 	c.RefreshAllGroup(groupCache)
 	c.RefreshAllGroupMembers(groupMemberCache)
@@ -64,10 +68,5 @@ func (c *Cache) RefreshAllGroup(groupCache map[uint32]*entity.Group) {
 
 // RefreshAllRKeyInfo 刷新所有RKey缓存
 func (c *Cache) RefreshAllRKeyInfo(rkeyCache entity.RKeyMap) {
-	var expTime int64 = math.MaxInt64
-	for _, ext := range rkeyCache {
-		expTime = int64(ext.ExpireTime)
-		break
-	}
-	refreshAllExpiredCacheOf(c, rkeyCache, expTime)
+	refreshAllCacheOf(c, rkeyCache)
 }


### PR DESCRIPTION
如果能在外围实现，就不应在cache中侵入式植入一个与基础实现无关的内容，这样会让代码十分臃肿并且增大基础架构维护难度。