### PR TITLE
[ERROR] 这个ParseTempMessage返回的消息不完整导致临时信息接收错误

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -137,6 +137,13 @@ func ParseGroupMessage(msg *message.PushMsgBody) *GroupMessage {
 
 func ParseTempMessage(msg *message.PushMsgBody) *TempMessage {
 	return &TempMessage{
+		ID:   msg.ContentHead.Sequence.Unwrap(),
+		Self: msg.ResponseHead.ToUin,
+		Sender: &Sender{
+			Uin:      msg.ResponseHead.FromUin,
+			UID:      msg.ResponseHead.FromUid.Unwrap(),
+			IsFriend: false,
+		},
 		Elements: ParseMessageElements(msg.Body.RichText.Elems),
 	}
 }


### PR DESCRIPTION
在接收临时消息时发现LagrangeGo这个库报错如下：
```
[2025-10-01 12:50:17] [DEBUG]: Lgr -> [client.(*QQClient).netLoop] rev pkt: trpc.msg.olpush.OlPushService.MsgPush seq: -1523624447
[2025-10-01 12:50:17] [ERROR]: Lgr -> [client.decodeOlPushServicePacket.func1] recovered from panic: runtime error: invalid memory address or nil pointer dereference
goroutine 86 [running]:
runtime/debug.Stack()
        /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
github.com/LagrangeDev/LagrangeGo/client.decodeOlPushServicePacket.func1()
        /root/go/pkg/mod/github.com/!lagrange!dev/!lagrange!go@v0.1.4/client/listener.go:34 +0x49
panic({0x9b53a0?, 0xf5a1a0?})
        /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.1.linux-amd64/src/runtime/panic.go:792 +0x132
github.com/LagrangeDev/LagrangeGo/client.decodeOlPushServicePacket(0xc0001ad108, 0xc0000c7900)
        /root/go/pkg/mod/github.com/!lagrange!dev/!lagrange!go@v0.1.4/client/listener.go:62 +0x108d
github.com/LagrangeDev/LagrangeGo/client.(*QQClient).netLoop.func2(0xc0000c7900)
        /root/go/pkg/mod/github.com/!lagrange!dev/!lagrange!go@v0.1.4/client/network.go:411 +0x150
created by github.com/LagrangeDev/LagrangeGo/client.(*QQClient).netLoop in goroutine 68
        /root/go/pkg/mod/github.com/!lagrange!dev/!lagrange!go@v0.1.4/client/network.go:396 +0x4a6

[2025-10-01 12:50:17] [ERROR]: Lgr -> [client.decodeOlPushServicePacket.func1] protobuf data: 0ad3020a850108e1c0a7cb0e1218755f317073505934456e305462344a3058734b436979507718e90728f5eb8f8a053218755f634e65646c564d6e6f6243364d766a657a66717031673a4008021a3090fa7bdd927551c01254cee9122d410b034e3de85ca69fc5248b0573e652ab7bef1b4a53d949e2095a293ed7777fe9892095cbe3ff012895cbe3ff011234088d01180b209eb6cc8e0428bcc8033089e6f2c60638015803609eb6cc8e8480808001e001bcc803800280c1f08cb484cfaee3011a92010a8f010a2108001089e6f2c606189eb6cc8e042000280a300038860140024a06e5ae8be4bd93125aaa025708008001008801009a014c7800c80100f00100f80100900200c80200980300a00300b00300b80300c00300b80400c00400ca0400d2050408031000800600b2060a0a080800100018002000a00780c1f08cb484cfaee30112064a040800600012060a040a023838
```
经过定位是在`client/listener.go:62`下报错
```
61 tempMsg := msgConverter.ParseTempMessage(pkg)
62 if tempMsg.Sender.Uin != c.Uin {
63 	c.TempMessageEvent.dispatch(c, tempMsg)
```
发现是`message.go/ParseTempMessage`返回的临时消息不完整导致报错，经过调试之后做了如下修复，现在可以正常接收临时消息了