### PR TITLE
fix: 调整群数据解析逻辑 修复群禁言无法解除的问题

### DIFF
--- a/client/event/group.go
+++ b/client/event/group.go
@@ -240,8 +240,10 @@ func ParseMemberIncreaseEvent(event *message.GroupChange) *GroupMemberIncrease {
 }
 
 func (g *GroupMemberDecrease) ResolveUin(f func(uid string, groupUin ...uint32) uint32) {
-	g.OperatorUin = f(g.OperatorUID, g.GroupUin)
 	g.UserUin = f(g.UserUID, g.GroupUin)
+	if g.IsKicked() {
+		g.OperatorUin = f(g.OperatorUID, g.GroupUin)
+	}
 }
 
 func ParseMemberDecreaseEvent(event *message.GroupChange) *GroupMemberDecrease {

--- a/client/packets/oidb/set_group_global_mute.go
+++ b/client/packets/oidb/set_group_global_mute.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/LagrangeDev/LagrangeGo/client/packets/pb/service/oidb"
+	"github.com/LagrangeDev/LagrangeGo/internal/proto"
 )
 
 func BuildSetGroupGlobalMuteReq(groupUin uint32, isMute bool) (*Packet, error) {
@@ -13,7 +14,7 @@ func BuildSetGroupGlobalMuteReq(groupUin uint32, isMute bool) (*Packet, error) {
 	}
 	body := &oidb.OidbSvcTrpcTcp0X89A_0{
 		GroupUin: groupUin,
-		State:    &oidb.OidbSvcTrpcTcp0X89A_0State{S: s},
+		State:    &oidb.OidbSvcTrpcTcp0X89A_0State{S: proto.Uint32(s)},
 	}
 	return BuildOidbPacket(0x89A, 0, body, false, false)
 }

--- a/client/packets/pb/service/oidb/OidbSvcTrpcTcp0x89A_0.pb.go
+++ b/client/packets/pb/service/oidb/OidbSvcTrpcTcp0x89A_0.pb.go
@@ -15,7 +15,7 @@ type OidbSvcTrpcTcp0X89A_0 struct {
 }
 
 type OidbSvcTrpcTcp0X89A_0State struct {
-	S uint32 `protobuf:"varint,17,opt"`
+	S proto.Option[uint32] `protobuf:"varint,17,opt"`
 	_ [0]func()
 }
 

--- a/client/packets/pb/service/oidb/OidbSvcTrpcTcp0x89A_0.proto
+++ b/client/packets/pb/service/oidb/OidbSvcTrpcTcp0x89A_0.proto
@@ -9,7 +9,7 @@ message OidbSvcTrpcTcp0x89A_0 {
 }
 
 message OidbSvcTrpcTcp0x89A_0State {
-  uint32 S = 17;
+  optional uint32 S = 17;
 }
 
 message OidbSvcTrpcTcp0x89A_0Response {


### PR DESCRIPTION
按照之前的逻辑 如果用户自己退出 会导致额外解析 刷新用户缓存 导致找不到退群人员信息 Uin 返回 0
并且 优先解析退群的人的数据 可以防止刷新缓存导致的数据丢失

解除群禁言的数据包序列化的时候 因为 S 的值为 0 导致最后数据丢失
添加 option 之后 可以保证字段为 0 时 也存在数据包中
[08 9A 11 22 05 08 E6 4E 12 00] => [08 9A 11 22 08 08 E6 4E 12 03 88 01 00]